### PR TITLE
Fix Zenodo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The rendered versions of these files can be found in the `rendered` folder as ei
 
 # Processed data
 
-The processed data files can be obtained from [this Zenodo archive](10.5281/zenodo.4004609).
+The processed data files can be obtained from [this Zenodo archive](https://doi.org/10.5281/zenodo.4004609).
 
 
 


### PR DESCRIPTION
This fix is a very minor one, as the current URL uses the text as a relative link, resulting into the not working `https://github.com/inbo/wwf-lpi/blob/master/10.5281/zenodo.4004609` whereas it should be https://doi.org/10.5281/zenodo.4004609.

It is really nice to see that INBO shares it's part of the analysis as an open reproducible analysis. Congratulations!